### PR TITLE
Added IRIDA Next JSON output file

### DIFF
--- a/conf/iridanext.config
+++ b/conf/iridanext.config
@@ -1,0 +1,19 @@
+iridanext {
+    enabled = true
+    output {
+        path = "${params.outdir}/iridanext.output.json.gz"
+        overwrite = true
+        files {
+            global = [
+            ]
+            samples = [
+                "**/**/detailed_summary.tsv",
+                "**/**/mlst.tsv",
+                "**/**/plasmidfinder.tsv",
+                "**/**/resfinder.tsv",
+                "**/**/results.xlsx",
+                "**/**/settings.txt",
+                "**/**/summary.tsv"]
+        }
+    }
+}

--- a/nextflow.config
+++ b/nextflow.config
@@ -179,7 +179,9 @@ singularity.registry = 'quay.io'
 // Nextflow plugins
 plugins {
     id 'nf-validation' // Validation of pipeline parameters and creation of an input channel from a sample sheet
+    id 'nf-iridanext@0.2.0' // Output for IRIDA Next
 }
+
 
 // Load igenomes.config if required
 if (!params.igenomes_ignore) {
@@ -190,6 +192,9 @@ if (!params.igenomes_ignore) {
 // Export these variables to prevent local Python/R libraries from conflicting with those in the container
 // The JULIA depot path has been adjusted to a fixed path `/usr/local/share/julia` that needs to be used for packages in the container.
 // See https://apeltzer.github.io/post/03-julia-lang-nextflow/ for details on that. Once we have a common agreement on where to keep Julia packages, this is adjustable.
+
+// Config file for nf-iridanext
+includeConfig 'conf/iridanext.config'
 
 env {
     PYTHONNOUSERSITE = 1


### PR DESCRIPTION
Added in the iridanext plugin and a iridanext.config to format output JSON for IRIDA-Next compatibility. Included all output files per sample. 

   - detailed_summary.tsv
    - mlst.tsv
    - plasmidfinder.tsv
    - resfinder.tsv
    - results.xlsx
    - settings.txt
    - summary.tsv

No global or meta information added. 

<!--
# nf-core/staramr pull request

Many thanks for contributing to nf-core/staramr!

Please fill in the appropriate checklist below (delete whatever is not relevant).
These are the most common things requested on pull requests (PRs).

Remember that PRs should be made against the dev branch, unless you're preparing a pipeline release.

Learn more about contributing: [CONTRIBUTING.md](https://github.com/nf-core/staramr/tree/master/.github/CONTRIBUTING.md)
-->

## PR checklist

- [ ] This comment contains a description of changes (with reason).
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added a new tool - have you followed the pipeline conventions in the [contribution docs](https://github.com/nf-core/staramr/tree/master/.github/CONTRIBUTING.md)
- [ ] If necessary, also make a PR on the nf-core/staramr _branch_ on the [nf-core/test-datasets](https://github.com/nf-core/test-datasets) repository.
- [ ] Make sure your code lints (`nf-core lint`).
- [ ] Ensure the test suite passes (`nextflow run . -profile test,docker --outdir <OUTDIR>`).
- [ ] Usage Documentation in `docs/usage.md` is updated.
- [ ] Output Documentation in `docs/output.md` is updated.
- [ ] `CHANGELOG.md` is updated.
- [ ] `README.md` is updated (including new tool citations and authors/contributors).
