### PR TITLE
Resolves #17 Add "StarAMR" prefix to each metadata field

### DIFF
--- a/conf/iridanext.config
+++ b/conf/iridanext.config
@@ -23,6 +23,15 @@ iridanext {
         }
         metadata {
             samples {
+                rename = [
+                    "Quality Module": "StarAMR Quality Module",
+                    "Predicted Phenotype": "StarAMR Predicted Phenotype",
+                    "CGE Predicted Phenotype": "StarAMR CGE Predicted Phenotype",
+                    "Genotype": "StarAMR Genotype",
+                    "Plasmid": "StarAMR Plasmid",
+                    "Scheme": "StarAMR Scheme",
+                    "Sequence Type": "StarAMR Sequence Type"
+                ]
             csv {
                 path = "**/merged_summary.tsv"
                 sep = "\t"

--- a/tests/main.nf.test
+++ b/tests/main.nf.test
@@ -26,31 +26,31 @@ nextflow_pipeline {
 
             // Salmonella tests
             def salmonella_metadata = iridanext_metadata.GCA_000008105
-            assert salmonella_metadata."Quality Module" == "Passed"
-            assert salmonella_metadata."Predicted Phenotype" == "streptomycin, kanamycin, ampicillin, amoxicillin/clavulanic acid, cefoxitin, ceftriaxone, chloramphenicol, trimethoprim, ciprofloxacin I/R, nalidixic acid, unknown[qacE_1_X68232], sulfisoxazole, tetracycline"
-            assert salmonella_metadata."CGE Predicted Phenotype" == "Spectinomycin, Streptomycin, Neomycin, Kanamycin, Lividomycin, Paromomycin, Ribostamycin, Amoxicillin, Amoxicillin+Clavulanic acid, Ampicillin, Ampicillin+Clavulanic acid, Cefotaxime, Cefoxitin, Ceftazidime, Piperacillin, Piperacillin+Tazobactam, Ticarcillin, Ticarcillin+Clavulanic acid, Cephalothin, Chloramphenicol, Trimethoprim, Nalidixic acid, Ciprofloxacin, Benzylkonium Chloride, Ethidium Bromide, Chlorhexidine, Cetylpyridinium Chloride, Sulfamethoxazole, Doxycycline, Tetracycline"
-            assert salmonella_metadata."Genotype" == "aadA1, aadA2, aadA2, aph(3'')-Ib, aph(3')-Ia, blaCMY-2, blaTEM-1B, cmlA1, dfrA12, gyrA (D87N), gyrA (S83F), qacE, sul1, sul3, tet(A)"
-            assert salmonella_metadata."Plasmid" == "IncFIB(K), IncFIB(S), IncFII(S)"
-            assert salmonella_metadata."Scheme" == "senterica_achtman_2"
-            assert salmonella_metadata."Sequence Type" == "66"
+            assert salmonella_metadata."StarAMR Quality Module" == "Passed"
+            assert salmonella_metadata."StarAMR Predicted Phenotype" == "streptomycin, kanamycin, ampicillin, amoxicillin/clavulanic acid, cefoxitin, ceftriaxone, chloramphenicol, trimethoprim, ciprofloxacin I/R, nalidixic acid, unknown[qacE_1_X68232], sulfisoxazole, tetracycline"
+            assert salmonella_metadata."StarAMR CGE Predicted Phenotype" == "Spectinomycin, Streptomycin, Neomycin, Kanamycin, Lividomycin, Paromomycin, Ribostamycin, Amoxicillin, Amoxicillin+Clavulanic acid, Ampicillin, Ampicillin+Clavulanic acid, Cefotaxime, Cefoxitin, Ceftazidime, Piperacillin, Piperacillin+Tazobactam, Ticarcillin, Ticarcillin+Clavulanic acid, Cephalothin, Chloramphenicol, Trimethoprim, Nalidixic acid, Ciprofloxacin, Benzylkonium Chloride, Ethidium Bromide, Chlorhexidine, Cetylpyridinium Chloride, Sulfamethoxazole, Doxycycline, Tetracycline"
+            assert salmonella_metadata."StarAMR Genotype" == "aadA1, aadA2, aadA2, aph(3'')-Ib, aph(3')-Ia, blaCMY-2, blaTEM-1B, cmlA1, dfrA12, gyrA (D87N), gyrA (S83F), qacE, sul1, sul3, tet(A)"
+            assert salmonella_metadata."StarAMR Plasmid" == "IncFIB(K), IncFIB(S), IncFII(S)"
+            assert salmonella_metadata."StarAMR Scheme" == "senterica_achtman_2"
+            assert salmonella_metadata."StarAMR Sequence Type" == "66"
             // Listeria tests
             def listeria_metadata = iridanext_metadata.GCF_000196035
-            assert listeria_metadata."Quality Module" == "Failed"
-            assert listeria_metadata."Predicted Phenotype" == "fosfomycin"
-            assert listeria_metadata."CGE Predicted Phenotype" == "Fosfomycin"
-            assert listeria_metadata."Genotype" == "fosX"
-            assert listeria_metadata."Plasmid" == "None"
-            assert listeria_metadata."Scheme" == "listeria_2"
-            assert listeria_metadata."Sequence Type" == "35"
+            assert listeria_metadata."StarAMR Quality Module" == "Failed"
+            assert listeria_metadata."StarAMR Predicted Phenotype" == "fosfomycin"
+            assert listeria_metadata."StarAMR CGE Predicted Phenotype" == "Fosfomycin"
+            assert listeria_metadata."StarAMR Genotype" == "fosX"
+            assert listeria_metadata."StarAMR Plasmid" == "None"
+            assert listeria_metadata."StarAMR Scheme" == "listeria_2"
+            assert listeria_metadata."StarAMR Sequence Type" == "35"
             // E coli tests
             def ecoli_metadata = iridanext_metadata.GCA_000947975
-            assert ecoli_metadata."Quality Module" == "Passed"
-            assert ecoli_metadata."Predicted Phenotype" == "streptomycin, kanamycin, ampicillin, ceftriaxone, trimethoprim, ciprofloxacin I/R, nalidixic acid, unknown[qacE_1_X68232], sulfisoxazole, tetracycline"
-            assert ecoli_metadata."CGE Predicted Phenotype" == "Streptomycin, Amoxicillin, Ampicillin, Aztreonam, Cefepime, Cefotaxime, Ceftazidime, Ceftriaxone, Piperacillin, Ticarcillin, Cephalothin, Trimethoprim, Nalidixic acid, Ciprofloxacin, Benzylkonium Chloride, Ethidium Bromide, Chlorhexidine, Cetylpyridinium Chloride, Sulfamethoxazole, Doxycycline, Tetracycline"
-            assert ecoli_metadata."Genotype" == "aph(3'')-Ib, aph(6)-Id, blaCTX-M-15, blaTEM-1B, dfrA7, gyrA (S83A), qacE, sul1, sul2, tet(A)"
-            assert ecoli_metadata."Plasmid" == "IncQ1"
-            assert ecoli_metadata."Scheme" == "ecoli_achtman_4"
-            assert ecoli_metadata."Sequence Type" == "678"
+            assert ecoli_metadata."StarAMR Quality Module" == "Passed"
+            assert ecoli_metadata."StarAMR Predicted Phenotype" == "streptomycin, kanamycin, ampicillin, ceftriaxone, trimethoprim, ciprofloxacin I/R, nalidixic acid, unknown[qacE_1_X68232], sulfisoxazole, tetracycline"
+            assert ecoli_metadata."StarAMR CGE Predicted Phenotype" == "Streptomycin, Amoxicillin, Ampicillin, Aztreonam, Cefepime, Cefotaxime, Ceftazidime, Ceftriaxone, Piperacillin, Ticarcillin, Cephalothin, Trimethoprim, Nalidixic acid, Ciprofloxacin, Benzylkonium Chloride, Ethidium Bromide, Chlorhexidine, Cetylpyridinium Chloride, Sulfamethoxazole, Doxycycline, Tetracycline"
+            assert ecoli_metadata."StarAMR Genotype" == "aph(3'')-Ib, aph(6)-Id, blaCTX-M-15, blaTEM-1B, dfrA7, gyrA (S83A), qacE, sul1, sul2, tet(A)"
+            assert ecoli_metadata."StarAMR Plasmid" == "IncQ1"
+            assert ecoli_metadata."StarAMR Scheme" == "ecoli_achtman_4"
+            assert ecoli_metadata."StarAMR Sequence Type" == "678"
 
             // Check the commandline parameters
             // Salmonella


### PR DESCRIPTION
Addressing the [issue 17](https://github.com/phac-nml/staramrnf/issues/17) to add StarAMR to prefix for metadata field to make the `nf-test` more readible and compatible with `Mikrokondo`. 
