### PR TITLE
Added two additional metadata tags and nf-test asserts

### DIFF
--- a/conf/iridanext.config
+++ b/conf/iridanext.config
@@ -30,7 +30,9 @@ iridanext {
                     "Genotype": "StarAMR Genotype",
                     "Plasmid": "StarAMR Plasmid",
                     "Scheme": "StarAMR Scheme",
-                    "Sequence Type": "StarAMR Sequence Type"
+                    "Sequence Type": "StarAMR Sequence Type",
+                    "N50 value": "StarAMR N50 value",
+                    "Genome Length": "StarAMR Genome Length"
                 ]
             csv {
                 path = "**/merged_summary.tsv"

--- a/tests/main.nf.test
+++ b/tests/main.nf.test
@@ -33,6 +33,9 @@ nextflow_pipeline {
             assert salmonella_metadata."StarAMR Plasmid" == "IncFIB(K), IncFIB(S), IncFII(S)"
             assert salmonella_metadata."StarAMR Scheme" == "senterica_achtman_2"
             assert salmonella_metadata."StarAMR Sequence Type" == "66"
+            assert salmonella_metadata."StarAMR N50 value": "4755700"
+            assert salmonella_metadata."StarAMR Genome Length": "4944000"
+
             // Listeria tests
             def listeria_metadata = iridanext_metadata.GCF_000196035
             assert listeria_metadata."StarAMR Quality Module" == "Failed"
@@ -42,6 +45,9 @@ nextflow_pipeline {
             assert listeria_metadata."StarAMR Plasmid" == "None"
             assert listeria_metadata."StarAMR Scheme" == "listeria_2"
             assert listeria_metadata."StarAMR Sequence Type" == "35"
+            assert listeria_metadata."StarAMR N50 value": "2944528"
+            assert listeria_metadata."StarAMR Genome Length": "2944528"
+
             // E coli tests
             def ecoli_metadata = iridanext_metadata.GCA_000947975
             assert ecoli_metadata."StarAMR Quality Module" == "Passed"
@@ -51,6 +57,8 @@ nextflow_pipeline {
             assert ecoli_metadata."StarAMR Plasmid" == "IncQ1"
             assert ecoli_metadata."StarAMR Scheme" == "ecoli_achtman_4"
             assert ecoli_metadata."StarAMR Sequence Type" == "678"
+            assert ecoli_metadata."StarAMR N50 value": "122025"
+            assert ecoli_metadata."StarAMR Genome Length": "5333525"
 
             // Check the commandline parameters
             // Salmonella


### PR DESCRIPTION
Added the metadata prefixe "StarAMR" to metadata from `staramrnf ` (`Genome Length`, and `N50 value`) so that all metadata tags in the IRIDA-Next output (`iridanext.output.json.gz`) would be included. Will help differentiate outputs of StarAMR from others on IRIDA-Next and increase compatibility with tools like Mikrokondo. 

In addition to renaming the metadata tags I added an assert statements for the metadata for `nf-test` 

## PR checklist

- [x] This comment contains a description of changes (with reason).
- [x] If you've fixed a bug or added code that should be tested, add tests!
- [x] Make sure your code lints (`nf-core lint`).
- [x] Ensure the test suite passes (`nextflow run . -profile test,docker --outdir <OUTDIR>`).
